### PR TITLE
Switch to IndexedDB and deploy to GH pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy to Pages
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+      - name: Install
+        run: |
+          cd client
+          npm ci
+      - name: Build
+        run: |
+          cd client
+          npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: client/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A comprehensive system that consists of a Telegram bot and a website to save and
 - 🔄 **Real-time Updates**: Automatically refresh URL list
 - 🖼️ **Rich URL Previews**: Show title, description, images, source badges, and tags
 - 🏗️ **Clean Architecture**: Well-structured codebase following Clean Architecture principles
+- 💾 **Offline Storage**: Save URLs in the browser with IndexedDB
 
 ## 🎯 Supported Platforms
 
@@ -230,6 +231,14 @@ npm run dev     # Start development server
 npm run build   # Build for production
 npm run preview # Preview production build
 ```
+
+### Deploying to GitHub Pages
+
+The workflow in `.github/workflows/pages.yml` builds the `client` app and publishes the `dist` folder to GitHub Pages whenever changes are pushed to the `main` branch.
+
+1. Commit your changes and push to `main`.
+2. GitHub Actions will build the Vite project and deploy it.
+3. The site will be available under the repository's Pages URL.
 
 ## 🔧 Troubleshooting
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -468,6 +468,29 @@ body {
   font-size: 0.95rem;
 }
 
+/* ===== ADD URL FORM ===== */
+.add-url-form {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+}
+
+.add-url-input {
+  flex: 1;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+}
+
+.add-url-btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
 /* ===== LAYOUT CONTROLS ===== */
 .layout-controls {
   display: flex;

--- a/client/src/db.ts
+++ b/client/src/db.ts
@@ -1,0 +1,50 @@
+export type UrlSource = 'facebook' | 'instagram' | 'threads' | 'youtube';
+export interface UrlData {
+  _id: string;
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  source?: UrlSource;
+  tags?: string[];
+  createdAt: string;
+}
+
+const DB_NAME = 'url-saver';
+const STORE_NAME = 'urls';
+const DB_VERSION = 1;
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onerror = () => reject(request.error);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: '_id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+export async function getUrls(): Promise<UrlData[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.getAll();
+    req.onsuccess = () => resolve(req.result as UrlData[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function saveUrl(data: UrlData): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(data);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}


### PR DESCRIPTION
## Summary
- store URLs in IndexedDB on the client
- add form to add new URLs directly
- create helper for IndexedDB access
- add GitHub Actions workflow to deploy the client to Pages
- document Pages deployment and offline storage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683bc60ee048832a8953fcacffdd0308